### PR TITLE
Make string comparison for digitalAddressTypes ignore case

### DIFF
--- a/OMC/Core/Domain/ZhvModels/ZhvModels/Mapping/Models/POCOs/OpenKlant/v2/PartyResults.cs
+++ b/OMC/Core/Domain/ZhvModels/ZhvModels/Mapping/Models/POCOs/OpenKlant/v2/PartyResults.cs
@@ -205,9 +205,13 @@ namespace ZhvModels.Mapping.Models.POCOs.OpenKlant.v2
             PartyResult party,
             DigitalAddressLong digitalAddress,
             OmcConfiguration configuration,
+            // ReSharper disable once RedundantAssignment
             ref PartyResult fallbackEmailOwningParty,
+            // ReSharper disable once RedundantAssignment
             ref PartyResult fallbackPhoneOwningParty,
+            // ReSharper disable once RedundantAssignment
             ref string fallbackEmailAddress,
+            // ReSharper disable once RedundantAssignment
             ref string fallbackPhoneNumber)
         {
             // Determine email and phone for this address
@@ -255,9 +259,9 @@ namespace ZhvModels.Mapping.Models.POCOs.OpenKlant.v2
         private static DistributionChannels DetermineDistributionChannel(
             DigitalAddressLong digitalAddress, OmcConfiguration configuration)
         {
-            return digitalAddress.Type == configuration.AppSettings.Variables.EmailGenericDescription()
+            return string.Equals(digitalAddress.Type, configuration.AppSettings.Variables.EmailGenericDescription(), StringComparison.CurrentCultureIgnoreCase)
                 ? DistributionChannels.Email
-                : digitalAddress.Type == configuration.AppSettings.Variables.PhoneGenericDescription()
+                : string.Equals(digitalAddress.Type, configuration.AppSettings.Variables.PhoneGenericDescription(), StringComparison.CurrentCultureIgnoreCase)
                     ? DistributionChannels.Sms
 
                     // NOTE: Any address type doesn't match the generic address types defined in the app settings


### PR DESCRIPTION
DigitalAddresTypes are compared to the Values in the appsettings. This is case sensetive. This pull request will make it so the comparison ignores cases.