### PR TITLE
Use contains in digitalAddress type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.15.3
+
+- Update DetermineDistributionChannel to check against "Telefoon" and "telefoonnummer" as digitalAddressType since OpenKlant v2.4.0.
+
+## 1.15.2
+
+- Update some documentation. 
+
 ## 1.15.1
 
 - Add more personal data to KTO call to Expoint.

--- a/Documentation/OMC - Documentation.md
+++ b/Documentation/OMC - Documentation.md
@@ -1,6 +1,6 @@
 <h1 id="start">OMC Documentation</h1>
 
-v.1.15.1
+v.1.15.3
 
 © 2023-2025, Worth Systems.
 
@@ -533,6 +533,8 @@ but `environment variables` are easier to be adjusted by the end users of **OMC*
   "AllowedHosts": "*"
 }
 ```
+
+> **NOTE:** In "OppenKlant v 2.4.0 " the compared value of "TelefoonOmschrijvingGeneriek" has changed to "telefoonnummer" But this is handled in the code for now.
 
 > Full content of `manager.appsettings.json` file for **Secrets Manager** project.
 

--- a/OMC/Core/Domain/ZhvModels/ZhvModels/Mapping/Models/POCOs/OpenKlant/v2/PartyResults.cs
+++ b/OMC/Core/Domain/ZhvModels/ZhvModels/Mapping/Models/POCOs/OpenKlant/v2/PartyResults.cs
@@ -261,9 +261,9 @@ namespace ZhvModels.Mapping.Models.POCOs.OpenKlant.v2
         {
             return string.Equals(digitalAddress.Type, configuration.AppSettings.Variables.EmailGenericDescription(), StringComparison.CurrentCultureIgnoreCase)
                 ? DistributionChannels.Email
-                : string.Equals(digitalAddress.Type, configuration.AppSettings.Variables.PhoneGenericDescription(), StringComparison.CurrentCultureIgnoreCase)
+                : digitalAddress.Type.Contains(configuration.AppSettings.Variables.PhoneGenericDescription(), StringComparison.CurrentCultureIgnoreCase)
                     ? DistributionChannels.Sms
-
+                    // NOTE: We use Contains because there is a difference between v1 "Telefoon" and v2 (v2.4.0 +) "telefoonnummer".
                     // NOTE: Any address type doesn't match the generic address types defined in the app settings
                     : DistributionChannels.Unknown;
         }

--- a/OMC/Infrastructure/WebApi/EventsHandler/EventsHandler.csproj
+++ b/OMC/Infrastructure/WebApi/EventsHandler/EventsHandler.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <!-- Project -->
     <AssemblyName>OMC.EventsHandler</AssemblyName>
-    <VersionPrefix>1.15.1</VersionPrefix>
+    <VersionPrefix>1.15.3</VersionPrefix>
 
     <TargetFramework>net8.0</TargetFramework>
 


### PR DESCRIPTION
Since OpenKlant v 2.4.0 The SoortDigitaalAdres has been made into a enum. It changed the Common Used "Telefoon" to "telefoonnummer". This makes it so it uses contains instead of equals. This should work as long as the enum value starts with "telefoon" Case Insensitive 